### PR TITLE
Update init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,7 @@ class cerebro (
   Array            $java_opts      = $::cerebro::params::java_opts,
   Optional[Stdlib::Unixpath] $java_home = $::cerebro::params::java_home,
   Optional[Hash] $basic_auth_settings   = $::cerebro::params::basic_auth_settings,
-  Optional[Stdlib::Ip_address] $address = $::cerebro::params::address,
+  Optional[Stdlib::Ip::Address] $address = $::cerebro::params::address,
 ) inherits cerebro::params {
 
   if $manage_user {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,7 @@ class cerebro (
   Array            $java_opts      = $::cerebro::params::java_opts,
   Optional[Stdlib::Unixpath] $java_home = $::cerebro::params::java_home,
   Optional[Hash] $basic_auth_settings   = $::cerebro::params::basic_auth_settings,
-  Optional[Stdlib::Ip::Address] $address = $::cerebro::params::address,
+  Optional[Stdlib::IP::Address] $address = $::cerebro::params::address,
 ) inherits cerebro::params {
 
   if $manage_user {


### PR DESCRIPTION
fix line   Optional[Stdlib::Ip_address] $address = $::cerebro::params::address for   Optional[Stdlib::Ip::Address] $address = $::cerebro::params::address.
reference:
https://github.com/puppetlabs/puppetlabs-stdlib
Stdlib::Ip_address
This type is no longer available. To make use of this functionality, use Stdlib::IP::Address

Stdlib::IP::Address
The new format Matches any IP address, including both IPv4 and IPv6 addresses. It will match them either with or without an address prefix as used in CIDR format IPv4 addresses.